### PR TITLE
EDX-3277 Update unregister resp code check to 204 (v2.2-branch)

### DIFF
--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -89,7 +89,7 @@ func (k *keeperClient) Register() error {
 
 	if resp.StatusCode != http.StatusCreated {
 		var response BaseResponse
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %s", err.Error())
 		}
@@ -116,9 +116,9 @@ func (k *keeperClient) Unregister() error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNoContent {
 		var response BaseResponse
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %s", err.Error())
 		}
@@ -164,7 +164,7 @@ func (k *keeperClient) GetServiceEndpoint(serviceKey string) (types.ServiceEndpo
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return types.ServiceEndpoint{}, fmt.Errorf("failed to read response body: %s", err.Error())
 	}
@@ -206,7 +206,7 @@ func (k *keeperClient) GetAllServiceEndpoints() ([]types.ServiceEndpoint, error)
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %s", err.Error())
 	}
@@ -253,7 +253,7 @@ func (k *keeperClient) IsServiceAvailable(serviceKey string) (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("failed to read response body: %s", err.Error())
 	}

--- a/internal/pkg/keeper/mock_keeper.go
+++ b/internal/pkg/keeper/mock_keeper.go
@@ -7,7 +7,7 @@ package keeper
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +37,7 @@ func (mock *MockKeeper) Start() *httptest.Server {
 				mock.serviceLock.Lock()
 				defer mock.serviceLock.Unlock()
 
-				bodyBytes, err := ioutil.ReadAll(request.Body)
+				bodyBytes, err := io.ReadAll(request.Body)
 				if err != nil {
 					log.Printf("error reading request body: %s", err.Error())
 				}
@@ -138,7 +138,7 @@ func (mock *MockKeeper) Start() *httptest.Server {
 					delete(mock.serviceStore, key)
 				}
 
-				writer.WriteHeader(http.StatusOK)
+				writer.WriteHeader(http.StatusNoContent)
 			}
 		} else if strings.Contains(request.URL.Path, ApiPingRoute) {
 			switch request.Method {


### PR DESCRIPTION
Update unregister resp code check to 204 based on the deregister API change. Use io package instead to fix linter errors.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-registry/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-registry/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->