### PR TITLE
EDX-3323 Update Keeper Register method to invoke PUT API

### DIFF
--- a/internal/pkg/keeper/client_test.go
+++ b/internal/pkg/keeper/client_test.go
@@ -114,6 +114,27 @@ func TestRegisterWithPingCallback(t *testing.T) {
 	require.True(t, receivedPing, "Never received health check ping")
 }
 
+func TestDuplicateRegister(t *testing.T) {
+	client := makeKeeperClient(t, getUniqueServiceName(), defaultServiceHost, defaultServicePort, true)
+
+	// Try to clean-up after test
+	defer func() {
+		_ = client.Unregister()
+	}()
+
+	// Register the service for the first time
+	err := client.Register()
+	require.NoError(t, err)
+
+	// Make sure the service already got registered
+	_, err = client.GetServiceEndpoint(client.serviceKey)
+	require.NoError(t, err, "Error getting service endpoint")
+
+	// Re-register the service and ensure no error occurred
+	err = client.Register()
+	require.NoError(t, err)
+}
+
 func TestUnregister(t *testing.T) {
 	client := makeKeeperClient(t, getUniqueServiceName(), defaultServiceHost, defaultServicePort, true)
 

--- a/internal/pkg/keeper/mock_keeper.go
+++ b/internal/pkg/keeper/mock_keeper.go
@@ -62,7 +62,23 @@ func (mock *MockKeeper) Start() *httptest.Server {
 
 				writer.Header().Set(ContentTypeJSON, ContentTypeJSON)
 				writer.WriteHeader(http.StatusCreated)
+			case http.MethodPut:
+				mock.serviceLock.Lock()
+				defer mock.serviceLock.Unlock()
 
+				bodyBytes, err := io.ReadAll(request.Body)
+				if err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+
+				var req AddRegistrationRequest
+				err = json.Unmarshal(bodyBytes, &req)
+				if err != nil {
+					log.Printf("error decoding request body: %s", err.Error())
+				}
+				mock.serviceStore[req.Registration.ServiceId] = req.Registration
+
+				writer.WriteHeader(http.StatusNoContent)
 			}
 		} else if strings.HasSuffix(request.URL.Path, ApiAllRegistrationRoute) {
 			switch request.Method {


### PR DESCRIPTION
Update Keeper Register method to invoke PUT API if service registry exists.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-registry/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-registry/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->